### PR TITLE
Remove lal requirement for arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [win]
 
@@ -30,20 +30,21 @@ requirements:
     - lscsoft-glue
     - python
     - pyyaml
-    - python-lal >=6.19.0
+    - python-lal >=6.19.0  # [not (osx and arm64)]
     - six
     - tqdm
   run_constrained:
     # pin to lscsoft-glue-2.0.0 to prevent file clobbering
     - lscsoft-glue >=2.0.0
+    - python-lal >=6.19.0  # [osx and arm64]
 
 test:
-  requires:               # [py>=37]
-    - matplotlib          # [py>=37]
-  source_files:           # [py>=37]
-    - test/               # [py>=37]
-  commands:               # [py>=37]
-    - make -C test check  # [py>=37]
+  requires:               # [py>=37 and not (osx and arm64)]
+    - matplotlib          # [py>=37 and not (osx and arm64)]
+  source_files:           # [py>=37 and not (osx and arm64)]
+    - test/               # [py>=37 and not (osx and arm64)]
+  commands:               # [py>=37 and not (osx and arm64)]
+    - make -C test check  # [py>=37 and not (osx and arm64)]
 
 about:
   home: https://git.ligo.org/kipp.cannon/python-ligo-lw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,12 +39,12 @@ requirements:
     - python-lal >=6.19.0  # [osx and arm64]
 
 test:
-  requires:               # [py>=37 and not (osx and arm64)]
-    - matplotlib          # [py>=37 and not (osx and arm64)]
-  source_files:           # [py>=37 and not (osx and arm64)]
-    - test/               # [py>=37 and not (osx and arm64)]
-  commands:               # [py>=37 and not (osx and arm64)]
-    - make -C test check  # [py>=37 and not (osx and arm64)]
+  requires:                                                # [py>=37 and not (osx and arm64)]
+    - matplotlib                                           # [py>=37 and not (osx and arm64)]
+  source_files:                                            # [py>=37 and not (osx and arm64)]
+    - test/                                                # [py>=37 and not (osx and arm64)]
+  commands:                                                # [py>=37 and not (osx and arm64)]
+    - make -C test -j ${CPU_COUNT} check PYTHON=${PYTHON}  # [py>=37 and not (osx and arm64)]
 
 about:
   home: https://git.ligo.org/kipp.cannon/python-ligo-lw


### PR DESCRIPTION
This PR removes the circular runtime requirement between this package and `python-lal` so that the osx_arm64 migration can actually occur here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
